### PR TITLE
refactor: Bundle module and change install method

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,48 @@
+name: Build and attach module on release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build companion module package
+        run: pnpm run package
+
+      - name: Read version from package.json
+        id: get_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          echo "Detected version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./slmngg-controller-${{ steps.get_version.outputs.version }}.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/README.md
+++ b/README.md
@@ -6,28 +6,9 @@ This module gives you control of [SLMN.GG](https://github.com/slmnio/slmngg-sfc)
 
 ### Preparing Companion
 
-- Install [Companion v3](https://user.bitfocus.io/download). You should make sure that any modules you require for production have also been updated to the new v3 format.
-- Create a folder somewhere in which you will install external modules, including this one
-- Run Companion and press the **developer settings cogwheel** in the top right, which will show the Developer modules path box. Choose your new folder here.
-
-  ![](https://raw.githubusercontent.com/wiki/bitfocus/companion-module-base/images/launcher-developer-mode.png)
-
-You'll now need to download and install this module into a subfolder. You can download the [full-setup.bat](https://github.com/slmnio/companion-module-slmngg/raw/master/full-setup.bat) file into your developer modules folder and run it. Otherwise, you can manually install everything you'll need.
-
-### Manual installation / running the script
-This is just an explanation of what the full setup batch file does. If you know what you're doing, just pull the commands you need from here.
-
-- Open a command prompt window in your developer modules folder. 
-- Install [Git](https://git-scm.com/) to make it easier to download updates:
-  `winget install Git.Git`
-- Download the module code: 
-  `git clone https://github.com/slmnio/companion-module-slmngg`
-- Enter the new downloaded folder
-  `cd companion-module-slmngg`
-- Install Node (v18 or higher). This installer uses the [v18 LTS](https://nodejs.org/en/blog/release/v18.12.0) version.
-  `winget install OpenJS.NodeJS.LTS`
-- Install dependencies
-  `npm install`
+- Install [Companion v4](https://user.bitfocus.io/download).
+- Go to the latest [release](https://github.com/slmnio/companion-module-slmngg/releases/latest) and download the `slmngg-controller-X.X.X.tgz` file.
+- Open Companion and go to the [**Modules**](http://localhost:8000/modules) tab. Press the **Import module package** button and select the downloaded file.
 
 ### Operating with SLMN.GG
 
@@ -56,6 +37,7 @@ The features we add get extensively tested in our productions, so you should fin
 
 # Getting updates
 
-We will keep pushing updates to this repository as new features get added. You can run the **update.bat** script in your module folder to get new updates and install any new dependencies.
+There's a variable `new_version_available` which will indicate if there's a new version of the module available.
+You can then follow the setup instructions again to download the latest version.
 
 

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -5,8 +5,8 @@
 	"description": "Control SLMN.GG from Companion",
 	"version": "0.0.0",
 	"license": "ISC",
-	"repository": "https://github.com/bitfocus/companion-module-slmngg-controller.git",
-	"bugs": "https://github.com/bitfocus/companion-module-slmngg-controller/issues",
+	"repository": "https://github.com/slmnio/companion-module-slmngg.git",
+	"bugs": "https://github.com/slmnio/companion-module-slmngg/issues",
 	"maintainers": [
 		{
 			"name": "SLMN"
@@ -14,7 +14,7 @@
 	],
 	"legacyIds": [],
 	"runtime": {
-		"type": "node18",
+		"type": "node22",
 		"api": "nodejs-ipc",
 		"apiVersion": "0.0.0",
 		"entrypoint": "..\\index.js"

--- a/full-setup.bat
+++ b/full-setup.bat
@@ -1,3 +1,0 @@
-@echo off
-call winget install Git.Git OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements
-start cmd "git clone https://github.com/slmnio/companion-module-slmngg && cd companion-module-slmngg && npm install"

--- a/package.json
+++ b/package.json
@@ -7,16 +7,18 @@
   "shortname": "slmngg",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "package": "companion-module-build"
   },
   "author": "SLMN",
   "license": "ISC",
   "dependencies": {
-    "@companion-module/base": "~1.4",
-    "obs-websocket-js": "^5.0.1",
-    "socket.io-client": "^4.5.1"
+    "@companion-module/base": "~1.12",
+    "compare-versions": "^6.1.1",
+    "obs-websocket-js": "^5.0.6",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
-    "@companion-module/tools": "^1.3.2"
-  }
+    "@companion-module/tools": "^2.3.0"
+  },
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/update.bat
+++ b/update.bat
@@ -1,3 +1,0 @@
-@echo off
-call git pull
-call npm install

--- a/variables.js
+++ b/variables.js
@@ -17,6 +17,8 @@ exports.updateVariableDefinitions = function () {
 	variables.push({ variableId: "client_stream_delay", name: "Stream delay reported by client's transmitter in seconds" })
 	variables.push({ variableId: "client_stream_delay_ms", name: "Stream delay reported by client's transmitter in milliseconds" })
 
+	variables.push({ variableId: "new_version_available", name: "New version available" })
+
 
 	variables.push({ variableId: "broadcast_key", name: "Broadcast key" })
 	variables.push({ variableId: "broadcast_name", name: "Broadcast name" })


### PR DESCRIPTION
Currently, we're still encouraging users to go through the dev module flow. Nowadays, companion has support for importing bundled module files, which greatly simplifies setup. This updates companion dependencies, adds a new GitHub action that pushes bundled modules to new releases, adds a `new_version_available` variable that lets users know about updates, and updates the instructions.